### PR TITLE
add x13 hashing for pow blocks

### DIFF
--- a/chaincfg/chainhash/hashfuncs.go
+++ b/chaincfg/chainhash/hashfuncs.go
@@ -39,6 +39,6 @@ func X13HashB(b []byte) []byte {
 }
 
 // X13HashH calculates X13Hash(b) and returns the resulting bytes as a Hash.
-func X13HashH(b []byte) []byte {
+func X13HashH(b []byte) Hash {
 	return Hash(gox13hash.Sum(b))
 }

--- a/chaincfg/chainhash/hashfuncs.go
+++ b/chaincfg/chainhash/hashfuncs.go
@@ -6,6 +6,7 @@
 package chainhash
 
 import "crypto/sha256"
+import "github.com/aguycalled/gox13hash"
 
 // HashB calculates hash(b) and returns the resulting bytes.
 func HashB(b []byte) []byte {
@@ -30,4 +31,14 @@ func DoubleHashB(b []byte) []byte {
 func DoubleHashH(b []byte) Hash {
 	first := sha256.Sum256(b)
 	return Hash(sha256.Sum256(first[:]))
+}
+
+// X13HashB calculates X13Hash(b) and returns the resulting bytes.
+func X13HashB(b []byte) []byte {
+	return gox13hash.Sum(b)
+}
+
+// X13HashH calculates X13Hash(b) and returns the resulting bytes as a Hash.
+func X13HashH(b []byte) []byte {
+	return Hash(gox13hash.Sum(b))
 }

--- a/chaincfg/chainhash/hashfuncs.go
+++ b/chaincfg/chainhash/hashfuncs.go
@@ -35,7 +35,8 @@ func DoubleHashH(b []byte) Hash {
 
 // X13HashB calculates X13Hash(b) and returns the resulting bytes.
 func X13HashB(b []byte) []byte {
-	return gox13hash.Sum(b)
+	hash := gox13hash.Sum(b)
+	return hash[:]
 }
 
 // X13HashH calculates X13Hash(b) and returns the resulting bytes as a Hash.

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,3 @@
-package: github.com/navcoin/navd
 import:
 - package: github.com/navcoin/navlog
 - package: github.com/navcoin/navutil
@@ -33,3 +32,4 @@ import:
 - package: github.com/jessevdk/go-flags
   version: 1679536dcc895411a9f5848d9a0250be7856448c
 - package: github.com/jrick/logrotate
+- package: github.com/aguycalled/gox13hash

--- a/wire/blockheader.go
+++ b/wire/blockheader.go
@@ -53,7 +53,12 @@ func (h *BlockHeader) BlockHash() chainhash.Hash {
 	buf := bytes.NewBuffer(make([]byte, 0, MaxBlockHeaderPayload))
 	_ = writeBlockHeader(buf, 0, h)
 
-	return chainhash.DoubleHashH(buf.Bytes())
+	if h.Version > 6 {
+		return chainhash.DoubleHashH(buf.Bytes())
+	} else {
+		return chainhash.X13HashH(buf.Bytes())
+	}
+
 }
 
 // BtcDecode decodes r using the navcoin protocol encoding into the receiver.


### PR DESCRIPTION
Blocks with version older than 7 use X13 instead of double SHA256 as hashing function.